### PR TITLE
Abbrev module

### DIFF
--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -84,6 +84,7 @@ impl Abbreviations {
     }
 
     /// Get the abbreviation associated with the given code.
+    #[inline]
     pub fn get(&self, code: u64) -> Option<&Abbreviation> {
         self.abbrevs.get(&code)
     }
@@ -143,21 +144,25 @@ impl Abbreviation {
     }
 
     /// Get this abbreviation's code.
+    #[inline]
     pub fn code(&self) -> u64 {
         self.code
     }
 
     /// Get this abbreviation's tag.
+    #[inline]
     pub fn tag(&self) -> constants::DwTag {
         self.tag
     }
 
     /// Return true if this abbreviation's type has children, false otherwise.
+    #[inline]
     pub fn has_children(&self) -> bool {
         self.has_children == constants::DW_CHILDREN_yes
     }
 
     /// Get this abbreviation's attributes.
+    #[inline]
     pub fn attributes(&self) -> &[AttributeSpecification] {
         &self.attributes[..]
     }
@@ -233,11 +238,13 @@ impl AttributeSpecification {
     }
 
     /// Get the attribute's name.
+    #[inline]
     pub fn name(&self) -> constants::DwAt {
         self.name
     }
 
     /// Get the attribute's form.
+    #[inline]
     pub fn form(&self) -> constants::DwForm {
         self.form
     }

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -1,0 +1,352 @@
+//! Functions for parsing DWARF debugging abbreviations.
+
+use constants;
+use parser::{Endianity, EndianBuf, Error, ParseResult, Format, UnitHeader};
+use parser::{parse_unsigned_leb, parse_u8};
+use std::collections::hash_map;
+
+/// An offset into the `.debug_abbrev` section.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DebugAbbrevOffset(pub u64);
+
+/// The `DebugAbbrev` struct represents the abbreviations describing
+/// `DebuggingInformationEntry`s' attribute names and forms found in the
+/// `.debug_abbrev` section.
+#[derive(Debug, Clone, Copy)]
+pub struct DebugAbbrev<'input, Endian>
+    where Endian: Endianity
+{
+    debug_abbrev_section: EndianBuf<'input, Endian>,
+}
+
+impl<'input, Endian> DebugAbbrev<'input, Endian>
+    where Endian: Endianity
+{
+    /// Construct a new `DebugAbbrev` instance from the data in the `.debug_abbrev`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_abbrev` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on OSX, etc.
+    ///
+    /// ```
+    /// use gimli::{DebugAbbrev, LittleEndian};
+    ///
+    /// # let buf = [0x00, 0x01, 0x02, 0x03];
+    /// # let read_debug_abbrev_section_somehow = || &buf;
+    /// let debug_abbrev = DebugAbbrev::<LittleEndian>::new(read_debug_abbrev_section_somehow());
+    /// ```
+    pub fn new(debug_abbrev_section: &'input [u8]) -> DebugAbbrev<'input, Endian> {
+        DebugAbbrev { debug_abbrev_section: EndianBuf::new(debug_abbrev_section) }
+    }
+
+    /// Parse the abbreviations at the given `offset` within this
+    /// `.debug_abbrev` section.
+    ///
+    /// The `offset` should generally be retrieved from a unit header.
+    pub fn abbreviations(&self,
+                         debug_abbrev_offset: DebugAbbrevOffset)
+                         -> ParseResult<Abbreviations> {
+        let input: &[u8] = self.debug_abbrev_section.into();
+        parse_abbreviations(&input[debug_abbrev_offset.0 as usize..]).map(|(_, abbrevs)| abbrevs)
+    }
+}
+
+/// A set of type abbreviations.
+///
+/// Construct an `Abbreviations` instance with the
+/// [`abbreviations()`](struct.UnitHeader.html#method.abbreviations)
+/// method.
+#[derive(Debug, Default, Clone)]
+pub struct Abbreviations {
+    abbrevs: hash_map::HashMap<u64, Abbreviation>,
+}
+
+impl Abbreviations {
+    /// Construct a new, empty set of abbreviations.
+    fn empty() -> Abbreviations {
+        Abbreviations { abbrevs: hash_map::HashMap::new() }
+    }
+
+    /// Insert an abbreviation into the set.
+    ///
+    /// Returns `Ok` if it is the first abbreviation in the set with its code,
+    /// `Err` if the code is a duplicate and there already exists an
+    /// abbreviation in the set with the given abbreviation's code.
+    fn insert(&mut self, abbrev: Abbreviation) -> Result<(), ()> {
+        match self.abbrevs.entry(abbrev.code) {
+            hash_map::Entry::Occupied(_) => Err(()),
+            hash_map::Entry::Vacant(entry) => {
+                entry.insert(abbrev);
+                Ok(())
+            }
+        }
+    }
+
+    /// Get the abbreviation associated with the given code.
+    pub fn get(&self, code: u64) -> Option<&Abbreviation> {
+        self.abbrevs.get(&code)
+    }
+}
+
+/// Parse a series of abbreviations, terminated by a null abbreviation.
+fn parse_abbreviations(mut input: &[u8]) -> ParseResult<(&[u8], Abbreviations)> {
+    let mut abbrevs = Abbreviations::empty();
+
+    loop {
+        let result = parse_null_abbreviation(input).map(|(rest, _)| (rest, None));
+        let result = result.or_else(|_| parse_abbreviation(input).map(|(rest, a)| (rest, Some(a))));
+        let (rest, abbrev) = try!(result);
+        input = rest;
+
+        match abbrev {
+            None => break,
+            Some(abbrev) => {
+                if let Err(_) = abbrevs.insert(abbrev) {
+                    return Err(Error::DuplicateAbbreviationCode);
+                }
+            }
+        }
+    }
+
+    Ok((input, abbrevs))
+}
+
+/// An abbreviation describes the shape of a `DebuggingInformationEntry`'s type:
+/// its code, tag type, whether it has children, and its set of attributes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Abbreviation {
+    code: u64,
+    tag: constants::DwTag,
+    has_children: constants::DwChildren,
+    attributes: Vec<AttributeSpecification>,
+}
+
+impl Abbreviation {
+    /// Construct a new `Abbreviation`.
+    ///
+    /// ### Panics
+    ///
+    /// Panics if `code` is `0`.
+    pub fn new(code: u64,
+               tag: constants::DwTag,
+               has_children: constants::DwChildren,
+               attributes: Vec<AttributeSpecification>)
+               -> Abbreviation {
+        assert!(code != 0);
+        Abbreviation {
+            code: code,
+            tag: tag,
+            has_children: has_children,
+            attributes: attributes,
+        }
+    }
+
+    /// Get this abbreviation's code.
+    pub fn code(&self) -> u64 {
+        self.code
+    }
+
+    /// Get this abbreviation's tag.
+    pub fn tag(&self) -> constants::DwTag {
+        self.tag
+    }
+
+    /// Return true if this abbreviation's type has children, false otherwise.
+    pub fn has_children(&self) -> bool {
+        self.has_children == constants::DW_CHILDREN_yes
+    }
+
+    /// Get this abbreviation's attributes.
+    pub fn attributes(&self) -> &[AttributeSpecification] {
+        &self.attributes[..]
+    }
+}
+
+/// Parse an abbreviation's code.
+fn parse_abbreviation_code(input: &[u8]) -> ParseResult<(&[u8], u64)> {
+    let (rest, code) = try!(parse_unsigned_leb(input));
+    if code == 0 {
+        Err(Error::AbbreviationCodeZero)
+    } else {
+        Ok((rest, code))
+    }
+}
+
+/// Parse an abbreviation's tag.
+fn parse_abbreviation_tag(input: &[u8]) -> ParseResult<(&[u8], constants::DwTag)> {
+    let (rest, val) = try!(parse_unsigned_leb(input));
+    if val == 0 {
+        Err(Error::AbbreviationCodeZero)
+    } else {
+        Ok((rest, constants::DwTag(val)))
+    }
+}
+
+/// Parse an abbreviation's "does the type have children?" byte.
+fn parse_abbreviation_has_children(input: &[u8]) -> ParseResult<(&[u8], constants::DwChildren)> {
+    let (rest, val) = try!(parse_u8(input));
+    let val = constants::DwChildren(val);
+    if val == constants::DW_CHILDREN_no || val == constants::DW_CHILDREN_yes {
+        Ok((rest, val))
+    } else {
+        Err(Error::BadHasChildren)
+    }
+}
+
+/// Parse a non-null abbreviation.
+fn parse_abbreviation(input: &[u8]) -> ParseResult<(&[u8], Abbreviation)> {
+    let (rest, code) = try!(parse_abbreviation_code(input));
+    let (rest, tag) = try!(parse_abbreviation_tag(rest));
+    let (rest, has_children) = try!(parse_abbreviation_has_children(rest));
+    let (rest, attributes) = try!(parse_attribute_specifications(rest));
+    let abbrev = Abbreviation::new(code, tag, has_children, attributes);
+    Ok((rest, abbrev))
+}
+
+/// Parse a null abbreviation.
+fn parse_null_abbreviation(input: &[u8]) -> ParseResult<(&[u8], ())> {
+    let (rest, name) = try!(parse_unsigned_leb(input));
+    if name == 0 {
+        Ok((rest, ()))
+    } else {
+        Err(Error::ExpectedZero)
+    }
+
+}
+
+/// The description of an attribute in an abbreviated type. It is a pair of name
+/// and form.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AttributeSpecification {
+    name: constants::DwAt,
+    form: constants::DwForm,
+}
+
+impl AttributeSpecification {
+    /// Construct a new `AttributeSpecification` from the given name and form.
+    pub fn new(name: constants::DwAt, form: constants::DwForm) -> AttributeSpecification {
+        AttributeSpecification {
+            name: name,
+            form: form,
+        }
+    }
+
+    /// Get the attribute's name.
+    pub fn name(&self) -> constants::DwAt {
+        self.name
+    }
+
+    /// Get the attribute's form.
+    pub fn form(&self) -> constants::DwForm {
+        self.form
+    }
+
+    /// Return the size of the attribute, in bytes.
+    ///
+    /// Note that because some attributes are variably sized, the size cannot
+    /// always be known without parsing, in which case we return `None`.
+    pub fn size<'me, 'input, 'unit, Endian>(&'me self,
+                                            header: &'unit UnitHeader<'input, Endian>)
+                                            -> Option<usize>
+        where Endian: Endianity
+    {
+        match self.form {
+            constants::DW_FORM_addr => Some(header.address_size() as usize),
+
+            constants::DW_FORM_flag |
+            constants::DW_FORM_flag_present |
+            constants::DW_FORM_data1 |
+            constants::DW_FORM_ref1 => Some(1),
+
+            constants::DW_FORM_data2 |
+            constants::DW_FORM_ref2 => Some(2),
+
+            constants::DW_FORM_data4 |
+            constants::DW_FORM_ref4 => Some(4),
+
+            constants::DW_FORM_data8 |
+            constants::DW_FORM_ref8 => Some(8),
+
+            constants::DW_FORM_sec_offset |
+            constants::DW_FORM_ref_addr |
+            constants::DW_FORM_ref_sig8 |
+            constants::DW_FORM_strp => {
+                match header.format() {
+                    Format::Dwarf32 => Some(4),
+                    Format::Dwarf64 => Some(8),
+                }
+            }
+
+            constants::DW_FORM_block |
+            constants::DW_FORM_block1 |
+            constants::DW_FORM_block2 |
+            constants::DW_FORM_block4 |
+            constants::DW_FORM_exprloc |
+            constants::DW_FORM_ref_udata |
+            constants::DW_FORM_string |
+            constants::DW_FORM_sdata |
+            constants::DW_FORM_udata |
+            constants::DW_FORM_indirect => None,
+
+            // We don't know the size of unknown forms.
+            _ => None,
+        }
+    }
+}
+
+/// Parse an attribute's name.
+fn parse_attribute_name(input: &[u8]) -> ParseResult<(&[u8], constants::DwAt)> {
+    let (rest, val) = try!(parse_unsigned_leb(input));
+    Ok((rest, constants::DwAt(val)))
+}
+
+/// Parse an attribute's form.
+pub fn parse_attribute_form(input: &[u8]) -> ParseResult<(&[u8], constants::DwForm)> {
+    let (rest, val) = try!(parse_unsigned_leb(input));
+    Ok((rest, constants::DwForm(val)))
+}
+
+/// Parse a non-null attribute specification.
+fn parse_attribute_specification(input: &[u8]) -> ParseResult<(&[u8], AttributeSpecification)> {
+    let (rest, name) = try!(parse_attribute_name(input));
+    let (rest, form) = try!(parse_attribute_form(rest));
+    let spec = AttributeSpecification::new(name, form);
+    Ok((rest, spec))
+}
+
+/// Parse the null attribute specification.
+fn parse_null_attribute_specification(input: &[u8]) -> ParseResult<(&[u8], ())> {
+    let (rest, name) = try!(parse_unsigned_leb(input));
+    if name != 0 {
+        return Err(Error::ExpectedZero);
+    }
+
+    let (rest, form) = try!(parse_unsigned_leb(rest));
+    if form != 0 {
+        return Err(Error::ExpectedZero);
+    }
+
+    Ok((rest, ()))
+}
+
+/// Parse a series of attribute specifications, terminated by a null attribute
+/// specification.
+fn parse_attribute_specifications(mut input: &[u8])
+                                  -> ParseResult<(&[u8], Vec<AttributeSpecification>)> {
+    let mut attrs = Vec::new();
+
+    loop {
+        let result = parse_null_attribute_specification(input).map(|(rest, _)| (rest, None));
+        let result = result.or_else(|_| parse_attribute_specification(input).map(|(rest, a)| (rest, Some(a))));
+        let (rest, attr) = try!(result);
+        input = rest;
+
+        match attr {
+            None => break,
+            Some(attr) => attrs.push(attr),
+        };
+    }
+
+    Ok((input, attrs))
+}

--- a/src/abbrev.rs
+++ b/src/abbrev.rs
@@ -182,7 +182,7 @@ fn parse_abbreviation_code(input: &[u8]) -> ParseResult<(&[u8], u64)> {
 fn parse_abbreviation_tag(input: &[u8]) -> ParseResult<(&[u8], constants::DwTag)> {
     let (rest, val) = try!(parse_unsigned_leb(input));
     if val == 0 {
-        Err(Error::AbbreviationCodeZero)
+        Err(Error::AbbreviationTagZero)
     } else {
         Ok((rest, constants::DwTag(val)))
     }

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -69,7 +69,7 @@ macro_rules! dw {
                     $(
                         $name => write!(f, stringify!($name)),
                     )+
-                    otherwise => write!(f, "Unknown {}: {}", 
+                    otherwise => write!(f, "Unknown {}: {}",
                                         stringify!($struct_name),
                                         otherwise.0),
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,11 +15,12 @@ pub use constants::*;
 
 mod parser;
 pub use parser::{Endianity, LittleEndian, BigEndian};
-pub use parser::{Error, ParseResult};
-pub use parser::Format;
+pub use parser::{Error, ParseResult, Format};
 pub use parser::{DebugStrOffset, DebugLineOffset, DebugLocOffset, DebugMacinfoOffset, UnitOffset};
-pub use parser::{DebugAbbrev, DebugAbbrevOffset, Abbreviations, Abbreviation,
-                 AttributeSpecification};
 pub use parser::{DebugInfo, DebugInfoOffset, UnitHeadersIter, UnitHeader};
 pub use parser::{DebugTypes, DebugTypesOffset, TypeUnitHeadersIter, TypeUnitHeader};
 pub use parser::{EntriesCursor, DebuggingInformationEntry, AttrsIter, Attribute, AttributeValue};
+
+mod abbrev;
+pub use abbrev::{DebugAbbrev, DebugAbbrevOffset, Abbreviations, Abbreviation,
+                 AttributeSpecification};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,4 +14,12 @@ mod constants;
 pub use constants::*;
 
 mod parser;
-pub use parser::*;
+pub use parser::{Endianity, LittleEndian, BigEndian};
+pub use parser::{Error, ParseResult};
+pub use parser::Format;
+pub use parser::{DebugStrOffset, DebugLineOffset, DebugLocOffset, DebugMacinfoOffset, UnitOffset};
+pub use parser::{DebugAbbrev, DebugAbbrevOffset, Abbreviations, Abbreviation,
+                 AttributeSpecification};
+pub use parser::{DebugInfo, DebugInfoOffset, UnitHeadersIter, UnitHeader};
+pub use parser::{DebugTypes, DebugTypesOffset, TypeUnitHeadersIter, TypeUnitHeader};
+pub use parser::{EntriesCursor, DebuggingInformationEntry, AttrsIter, Attribute, AttributeValue};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -972,7 +972,8 @@ fn test_unit_version_incomplete() {
 
 /// Parse the `debug_abbrev_offset` in the compilation unit header.
 fn parse_debug_abbrev_offset<'input, Endian>
-    (input: EndianBuf<'input, Endian>, format: Format)
+    (input: EndianBuf<'input, Endian>,
+     format: Format)
      -> ParseResult<(EndianBuf<'input, Endian>, DebugAbbrevOffset)>
     where Endian: Endianity
 {
@@ -987,8 +988,7 @@ fn parse_debug_abbrev_offset<'input, Endian>
 fn test_parse_debug_abbrev_offset_32() {
     let buf = [0x01, 0x02, 0x03, 0x04];
 
-    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf),
-                                                Format::Dwarf32) {
+    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf32) {
         Ok((_, val)) => assert_eq!(val, DebugAbbrevOffset(0x04030201)),
         otherwise => panic!("Unexpected result: {:?}", otherwise),
     };
@@ -998,8 +998,7 @@ fn test_parse_debug_abbrev_offset_32() {
 fn test_parse_debug_abbrev_offset_32_incomplete() {
     let buf = [0x01, 0x02];
 
-    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf),
-                                                Format::Dwarf32) {
+    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf32) {
         Err(Error::UnexpectedEof) => assert!(true),
         otherwise => panic!("Unexpected result: {:?}", otherwise),
     };
@@ -1009,8 +1008,7 @@ fn test_parse_debug_abbrev_offset_32_incomplete() {
 fn test_parse_debug_abbrev_offset_64() {
     let buf = [0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08];
 
-    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf),
-                                                Format::Dwarf64) {
+    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf64) {
         Ok((_, val)) => assert_eq!(val, DebugAbbrevOffset(0x0807060504030201)),
         otherwise => panic!("Unexpected result: {:?}", otherwise),
     };
@@ -1020,8 +1018,7 @@ fn test_parse_debug_abbrev_offset_64() {
 fn test_parse_debug_abbrev_offset_64_incomplete() {
     let buf = [0x01, 0x02];
 
-    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf),
-                                                Format::Dwarf64) {
+    match parse_debug_abbrev_offset(EndianBuf::<LittleEndian>::new(&buf), Format::Dwarf64) {
         Err(Error::UnexpectedEof) => assert!(true),
         otherwise => panic!("Unexpected result: {:?}", otherwise),
     };
@@ -2865,7 +2862,8 @@ fn test_parse_type_signature_incomplete() {
 
 /// Parse a type unit header's type offset.
 fn parse_type_offset<'input, Endian>
-    (input: EndianBuf<'input, Endian>, format: Format)
+    (input: EndianBuf<'input, Endian>,
+     format: Format)
      -> ParseResult<(EndianBuf<'input, Endian>, DebugTypesOffset)>
     where Endian: Endianity
 {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -98,8 +98,9 @@ pub enum Error {
     /// An abbreviation declared that its code is zero, but zero is reserved for
     /// null records.
     AbbreviationCodeZero,
-    /// Found an unknown `DW_TAG_*` type.
-    UnknownTag,
+    /// An abbreviation declared that its tag is zero, but zero is reserved for
+    /// null records.
+    AbbreviationTagZero,
     /// The abbreviation's has-children byte was not one of
     /// `DW_CHILDREN_{yes,no}`.
     BadHasChildren,
@@ -137,7 +138,10 @@ impl error::Error for Error {
                 "An abbreviation declared that its code is zero,
                  but zero is reserved for null records"
             }
-            Error::UnknownTag => "Found an unknown `DW_TAG_*` type",
+            Error::AbbreviationTagZero => {
+                "An abbreviation declared that its tag is zero,
+                 but zero is reserved for null records"
+            }
             Error::BadHasChildren => {
                 "The abbreviation's has-children byte was not one of
                  `DW_CHILDREN_{yes,no}`"

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -101,6 +101,12 @@ pub enum Error {
     /// An abbreviation declared that its tag is zero, but zero is reserved for
     /// null records.
     AbbreviationTagZero,
+    /// An attribute specification declared that its name is zero, but zero is
+    /// reserved for null records.
+    AttributeNameZero,
+    /// An attribute specification declared that its form is zero, but zero is
+    /// reserved for null records.
+    AttributeFormZero,
     /// The abbreviation's has-children byte was not one of
     /// `DW_CHILDREN_{yes,no}`.
     BadHasChildren,
@@ -140,6 +146,14 @@ impl error::Error for Error {
             }
             Error::AbbreviationTagZero => {
                 "An abbreviation declared that its tag is zero,
+                 but zero is reserved for null records"
+            }
+            Error::AttributeNameZero => {
+                "An attribute specification declared that its name is zero,
+                 but zero is reserved for null records"
+            }
+            Error::AttributeFormZero => {
+                "An attribute specification declared that its form is zero,
                  but zero is reserved for null records"
             }
             Error::BadHasChildren => {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -4,7 +4,6 @@ use byteorder;
 use constants;
 use leb128;
 use abbrev::{DebugAbbrev, DebugAbbrevOffset, Abbreviations, Abbreviation, AttributeSpecification};
-use abbrev::parse_attribute_form;
 use std::cell::{Cell, RefCell};
 use std::error;
 use std::fmt::{self, Debug};
@@ -1350,7 +1349,7 @@ fn parse_attribute<'input, 'unit, Endian>
     loop {
         match form {
             constants::DW_FORM_indirect => {
-                let (rest, dynamic_form) = try!(parse_attribute_form(input.into()));
+                let (rest, dynamic_form) = try!(AttributeSpecification::parse_form(input.into()));
                 form = dynamic_form;
                 input = EndianBuf::new(rest);
                 continue;


### PR DESCRIPTION
This is an attempt at creating an abbrev module with a tests submodule. The abbrev module has required me to make various things in parser public, and the tests submodule has done the same for things in the abbrev module. So as a result, I need to restrict what gets exported in the toplevel lib.rs. It's all a bit ugly though. I need to think about this for a bit to see if there's a better way. Interested in your thoughts.

There's a few other useful changes in this pull request too. I'm happy to rebase them if we decide not to do the module changes.