### PR TITLE
Dont reparse same lebs multiple times

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -21,15 +21,9 @@ pub enum Error {
     BadUnsignedLeb128,
     /// An error parsing a signed LEB128 value.
     BadSignedLeb128,
-    /// An abbreviation declared that its code is zero, but zero is reserved for
-    /// null records.
-    AbbreviationCodeZero,
     /// An abbreviation declared that its tag is zero, but zero is reserved for
     /// null records.
     AbbreviationTagZero,
-    /// An attribute specification declared that its name is zero, but zero is
-    /// reserved for null records.
-    AttributeNameZero,
     /// An attribute specification declared that its form is zero, but zero is
     /// reserved for null records.
     AttributeFormZero,
@@ -66,16 +60,8 @@ impl error::Error for Error {
         match *self {
             Error::BadUnsignedLeb128 => "An error parsing an unsigned LEB128 value",
             Error::BadSignedLeb128 => "An error parsing a signed LEB128 value",
-            Error::AbbreviationCodeZero => {
-                "An abbreviation declared that its code is zero,
-                 but zero is reserved for null records"
-            }
             Error::AbbreviationTagZero => {
                 "An abbreviation declared that its tag is zero,
-                 but zero is reserved for null records"
-            }
-            Error::AttributeNameZero => {
-                "An attribute specification declared that its name is zero,
                  but zero is reserved for null records"
             }
             Error::AttributeFormZero => {


### PR DESCRIPTION
Before:
```
test bench_parsing_debug_abbrev ... bench:      33,643 ns/iter (+/- 6,243)
test bench_parsing_debug_info   ... bench:   5,914,364 ns/iter (+/- 819,837)
```

After:
```
test bench_parsing_debug_abbrev ... bench:      29,905 ns/iter (+/- 7,143)
test bench_parsing_debug_info   ... bench:   5,913,803 ns/iter (+/- 894,585)
```

Looks like a little bit of a speed up for parsing abbreviations, but its within the margin of error. Either way, I think this actually cleans up the loop-until-we-parse-a-null-thing code a bit.

What do you think @philipc?