### PR TITLE
Cursor performance

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -59,12 +59,14 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
             let mut cursor = unit.entries(&abbrevs);
 
             loop {
-                let entry = cursor.current()
-                    .expect("Should have a current entry")
-                    .expect("And should parse that entry OK");
+                {
+                    let entry = cursor.current_ref()
+                        .expect("Should have a current entry")
+                        .expect("And should parse that entry OK");
 
-                for attr in entry.attrs() {
-                    test::black_box(attr.expect("Should parse entry's attribute"));
+                    for attr in entry.attrs() {
+                        test::black_box(attr.expect("Should parse entry's attribute"));
+                    }
                 }
 
                 if let None = cursor.next_dfs() {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2051,15 +2051,15 @@ pub struct EntriesCursor<'input, 'abbrev, 'unit, Endian>
 impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endian>
     where Endian: Endianity
 {
-    /// Get the entry that the cursor is currently pointing to.
-    pub fn current<'me>
+    /// Get a reference to the entry that the cursor is currently pointing to.
+    pub fn current_ref<'me>
         (&'me mut self)
-         -> Option<ParseResult<DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>>> {
+         -> Option<ParseResult<&'me DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>>> {
 
         // First, check for a cached result.
         {
             if let Some(ref cached) = self.cached_current {
-                return Some(Ok(cached.clone()));
+                return Some(Ok(cached));
             }
         }
 
@@ -2083,11 +2083,22 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
                         unit: self.unit,
                     });
 
-                    Some(Ok(self.cached_current.as_ref().unwrap().clone()))
+                    Some(Ok(self.cached_current.as_ref().unwrap()))
                 } else {
                     Some(Err(Error::UnknownAbbreviation))
                 }
             }
+        }
+    }
+
+    /// Get the entry that the cursor is currently pointing to.
+    pub fn current<'me>
+        (&'me mut self)
+         -> Option<ParseResult<DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>>> {
+        match self.current_ref() {
+            Some(Ok(current)) => Some(Ok(current.clone())),
+            Some(Err(e)) => Some(Err(e)),
+            None => None,
         }
     }
 


### PR DESCRIPTION
This gives significant improvements to the debug_info benchmark (see numbers in the commits).

I haven't updated any of the examples to use `current_ref`, because it is quite unergonomic, due to the borrow checker: you can't call `next_dfs` and `next_sibling` while you still have a reference to the current entry. See the changes in `bench.rs` for example. It's also much worse if you want to use `while` instead of `loop`.

So we probably need to rethink the EntriesCursor API. I think the best way will be to avoid the user needing to call `current_ref`, and instead `next_dfs` and `next_sibling` should return the entry ref too. This means we need to change them to allow them to return the first entry when they are first called, rather than immediately skipping the current entry. This is more in line with how the `next` method works for iterators. I'm open to other ideas though, since I don't know what requirements you had when designing the current API.