### PR TITLE
Change `EntriesCursor` to parse in `next_*` instead of `current`

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -59,9 +59,7 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
             let mut cursor = unit.entries(&abbrevs);
 
             while cursor.next_dfs().expect("Should parse next dfs").is_some() {
-                let entry = cursor.current_ref()
-                    .expect("Should have a current entry")
-                    .expect("And should parse that entry OK");
+                let entry = cursor.current().expect("Should have a current entry");
 
                 for attr in entry.attrs() {
                     test::black_box(attr.expect("Should parse entry's attribute"));

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -69,7 +69,7 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
                     }
                 }
 
-                if let None = cursor.next_dfs() {
+                if let None = cursor.next_dfs().expect("Should parse next dfs") {
                     break;
                 }
             }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -58,9 +58,7 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
 
             let mut cursor = unit.entries(&abbrevs);
 
-            while cursor.next_dfs().expect("Should parse next dfs").is_some() {
-                let entry = cursor.current().expect("Should have a current entry");
-
+            while let Some((_, entry)) = cursor.next_dfs().expect("Should parse next dfs") {
                 for attr in entry.attrs() {
                     test::black_box(attr.expect("Should parse entry's attribute"));
                 }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -58,19 +58,13 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
 
             let mut cursor = unit.entries(&abbrevs);
 
-            loop {
-                {
-                    let entry = cursor.current_ref()
-                        .expect("Should have a current entry")
-                        .expect("And should parse that entry OK");
+            while cursor.next_dfs().expect("Should parse next dfs").is_some() {
+                let entry = cursor.current_ref()
+                    .expect("Should have a current entry")
+                    .expect("And should parse that entry OK");
 
-                    for attr in entry.attrs() {
-                        test::black_box(attr.expect("Should parse entry's attribute"));
-                    }
-                }
-
-                if let None = cursor.next_dfs().expect("Should parse next dfs") {
-                    break;
+                for attr in entry.attrs() {
+                    test::black_box(attr.expect("Should parse entry's attribute"));
                 }
             }
         }

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -72,7 +72,12 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>)
     where Endian: gimli::Endianity
 {
     let depth = Cell::new(0);
-    while let Some(entry) = entries.current().expect("Should parse the entry OK") {
+    while let Some(delta_depth) = entries.next_dfs().expect("Should parse next dfs") {
+        let entry = entries.current()
+            .expect("Should have a current entry")
+            .expect("And should parse that entry OK");
+
+        depth.set(depth.get() + delta_depth);
         let indent = || {
             for _ in 0..(depth.get() as usize) {
                 print!("        ");
@@ -87,10 +92,6 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>)
 
             indent();
             println!("    {} = {:?}", attr.name(), attr.value());
-        }
-
-        if let Some(delta_depth) = entries.next_dfs().expect("Should parse next dfs") {
-            depth.set(depth.get() + delta_depth);
         }
     }
 }

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -73,9 +73,7 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>)
 {
     let depth = Cell::new(0);
     while let Some(delta_depth) = entries.next_dfs().expect("Should parse next dfs") {
-        let entry = entries.current()
-            .expect("Should have a current entry")
-            .expect("And should parse that entry OK");
+        let entry = entries.current().expect("Should have a current entry");
 
         depth.set(depth.get() + delta_depth);
         let indent = || {

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -72,9 +72,7 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>)
     where Endian: gimli::Endianity
 {
     let depth = Cell::new(0);
-    while let Some(entry) = entries.current() {
-        let entry = entry.expect("Should parse the entry OK");
-
+    while let Some(entry) = entries.current().expect("Should parse the entry OK") {
         let indent = || {
             for _ in 0..(depth.get() as usize) {
                 print!("        ");
@@ -91,7 +89,7 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>)
             println!("    {} = {:?}", attr.name(), attr.value());
         }
 
-        if let Some(delta_depth) = entries.next_dfs() {
+        if let Some(delta_depth) = entries.next_dfs().expect("Should parse next dfs") {
             depth.set(depth.get() + delta_depth);
         }
     }

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -72,9 +72,7 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>)
     where Endian: gimli::Endianity
 {
     let depth = Cell::new(0);
-    while let Some(delta_depth) = entries.next_dfs().expect("Should parse next dfs") {
-        let entry = entries.current().expect("Should have a current entry");
-
+    while let Some((delta_depth, entry)) = entries.next_dfs().expect("Should parse next dfs") {
         depth.set(depth.get() + delta_depth);
         let indent = || {
             for _ in 0..(depth.get() as usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,14 @@
 //! let mut entries = unit.entries(&abbrevs);
 //!
 //! // Keep iterating entries while the cursor is not exhausted.
-//! while let Some(entry) = entries.current().expect("Should parse the entry OK") {
+//! while let Some(_) = entries.next_dfs().expect("Should parse next entry") {
+//!     let entry = entries.current()
+//!         .expect("Should have a current entry")
+//!         .expect("And should parse that entry OK");
 //!     // If we find an entry for a function, print it.
 //!     if entry.tag() == gimli::DW_TAG_subprogram {
 //!         println!("Found a function: {:?}", entry);
 //!     }
-//!
-//!     // Advance the cursor to the next entry, in DFS order.
-//!     entries.next_dfs();
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,9 +44,7 @@
 //!
 //! // Keep iterating entries while the cursor is not exhausted.
 //! while let Some(_) = entries.next_dfs().expect("Should parse next entry") {
-//!     let entry = entries.current()
-//!         .expect("Should have a current entry")
-//!         .expect("And should parse that entry OK");
+//!     let entry = entries.current().expect("Should have a current entry");
 //!     // If we find an entry for a function, print it.
 //!     if entry.tag() == gimli::DW_TAG_subprogram {
 //!         println!("Found a function: {:?}", entry);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,9 +43,7 @@
 //! let mut entries = unit.entries(&abbrevs);
 //!
 //! // Keep iterating entries while the cursor is not exhausted.
-//! while let Some(entry) = entries.current() {
-//!     let entry = entry.expect("Should parse the entry OK");
-//!
+//! while let Some(entry) = entries.current().expect("Should parse the entry OK") {
 //!     // If we find an entry for a function, print it.
 //!     if entry.tag() == gimli::DW_TAG_subprogram {
 //!         println!("Found a function: {:?}", entry);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,7 @@
 //! let mut entries = unit.entries(&abbrevs);
 //!
 //! // Keep iterating entries while the cursor is not exhausted.
-//! while let Some(_) = entries.next_dfs().expect("Should parse next entry") {
-//!     let entry = entries.current().expect("Should have a current entry");
+//! while let Some((_, entry)) = entries.next_dfs().expect("Should parse next entry") {
 //!     // If we find an entry for a function, print it.
 //!     if entry.tag() == gimli::DW_TAG_subprogram {
 //!         println!("Found a function: {:?}", entry);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2266,7 +2266,7 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
 
     /// Move the cursor to the next sibling DIE of the current one.
     ///
-    /// Returns `Ok(Some(()))` when the cursor has been moved to
+    /// Returns `Ok(Some(entry))` when the cursor has been moved to
     /// the next sibling, `Ok(None)` when there is no next sibling.
     ///
     /// The depth of the cursor is never changed if this method returns `Ok`.
@@ -2370,7 +2370,9 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
     ///     }
     /// }
     /// ```
-    pub fn next_sibling(&mut self) -> ParseResult<Option<()>> {
+    pub fn next_sibling<'me>
+        (&'me mut self)
+         -> ParseResult<Option<(&'me DebuggingInformationEntry<'input, 'abbrev, 'unit, Endian>)>> {
         if self.cached_current.is_some() {
             let sibling_ptr = self.current().unwrap().attr_value(constants::DW_AT_sibling);
             if let Some(AttributeValue::UnitRef(offset)) = sibling_ptr {
@@ -2380,11 +2382,7 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
                     self.input = &self.unit.range_from(offset..);
                     self.cached_current = None;
                     try!(self.next_entry());
-                    if self.cached_current.is_some() {
-                        return Ok(Some(()));
-                    } else {
-                        return Ok(None);
-                    }
+                    return Ok(self.current());
                 }
             }
 
@@ -2402,11 +2400,7 @@ impl<'input, 'abbrev, 'unit, Endian> EntriesCursor<'input, 'abbrev, 'unit, Endia
 
             // The next entry will be the sibling, so parse it
             try!(self.next_entry());
-            if self.cached_current.is_some() {
-                Ok(Some(()))
-            } else {
-                Ok(None)
-            }
+            Ok(self.current())
         } else {
             Ok(None)
         }

--- a/tests/entries_cursor.rs
+++ b/tests/entries_cursor.rs
@@ -85,9 +85,12 @@ fn assert_next_sibling<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCurso
                                                        name: &'static str)
     where Endian: Endianity
 {
-    cursor.next_sibling()
-        .expect("Should parse next sibling")
-        .expect("Should not be done with traversal");
+    {
+        let entry = cursor.next_sibling()
+            .expect("Should parse next sibling")
+            .expect("Should not be done with traversal");
+        assert_entry_name(entry, name);
+    }
     assert_current_name(cursor, name);
 }
 

--- a/tests/entries_cursor.rs
+++ b/tests/entries_cursor.rs
@@ -31,7 +31,9 @@ fn assert_next_dfs<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCursor<'i
                                                    depth: isize)
     where Endian: Endianity
 {
-    assert_eq!(cursor.next_dfs().expect("Should not be done with traversal"),
+    assert_eq!(cursor.next_dfs()
+                   .expect("Should parse next dfs")
+                   .expect("Should not be done with traversal"),
                depth);
     assert_current_name(cursor, name);
 }
@@ -44,7 +46,9 @@ fn assert_next_sibling<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCurso
                                                        name: &'static str)
     where Endian: Endianity
 {
-    cursor.next_sibling().expect("Should not be done with traversal");
+    cursor.next_sibling()
+        .expect("Should parse next sibling")
+        .expect("Should not be done with traversal");
     assert_current_name(cursor, name);
 }
 
@@ -221,8 +225,8 @@ fn test_cursor_next_dfs() {
     assert_next_dfs(&mut cursor, "009", 1);
     assert_next_dfs(&mut cursor, "010", -2);
 
-    assert!(cursor.next_dfs().is_none());
-    assert!(cursor.current().is_none());
+    assert!(cursor.next_dfs().expect("Should parse next dfs").is_none());
+    assert!(cursor.current().expect("Should parse current entry").is_none());
 }
 
 #[test]
@@ -257,8 +261,8 @@ fn test_cursor_next_sibling_no_sibling_ptr() {
 
     // And now the cursor should be exhausted.
 
-    assert!(cursor.next_sibling().is_none());
-    assert!(cursor.current().is_none());
+    assert!(cursor.next_sibling().expect("Should parse next sibling").is_none());
+    assert!(cursor.current().expect("Should parse current entry").is_none());
 }
 
 #[test]
@@ -420,6 +424,6 @@ fn test_cursor_next_sibling_with_sibling_ptr() {
 
     // And now the cursor should be exhausted.
 
-    assert!(cursor.next_sibling().is_none());
-    assert!(cursor.current().is_none());
+    assert!(cursor.next_sibling().expect("Should parse next sibling").is_none());
+    assert!(cursor.current().expect("Should parse current entry").is_none());
 }

--- a/tests/entries_cursor.rs
+++ b/tests/entries_cursor.rs
@@ -23,6 +23,33 @@ fn assert_current_name<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCurso
 }
 
 #[cfg(test)]
+fn assert_next_entry<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCursor<'input,
+                                                                                'abbrev,
+                                                                                'unit,
+                                                                                Endian>,
+                                                     name: &'static str)
+    where Endian: Endianity
+{
+    cursor.next_entry()
+        .expect("Should parse next entry")
+        .expect("Should have an entry");
+    assert_current_name(cursor, name);
+}
+
+#[cfg(test)]
+fn assert_next_entry_null<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCursor<'input,
+                                                                                     'abbrev,
+                                                                                     'unit,
+                                                                                     Endian>)
+    where Endian: Endianity
+{
+    cursor.next_entry()
+        .expect("Should parse next entry")
+        .expect("Should have an entry");
+    // assert!(cursor.current().expect("Should parse current entry").is_none());
+}
+
+#[cfg(test)]
 fn assert_next_dfs<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCursor<'input,
                                                                               'abbrev,
                                                                               'unit,
@@ -195,6 +222,49 @@ const ENTRIES_CURSOR_TESTS_DEBUG_INFO_BUF: [u8; 71] = [
     // End of children
     0x00
 ];
+
+#[test]
+#[cfg_attr(rustfmt, rustfmt_skip)]
+fn test_cursor_next_entry() {
+    let info_buf = &ENTRIES_CURSOR_TESTS_DEBUG_INFO_BUF;
+    let debug_info = DebugInfo::<LittleEndian>::new(info_buf);
+
+    let unit = debug_info.units().next()
+        .expect("should have a unit result")
+        .expect("and it should be ok");
+
+    let abbrevs_buf = &ENTRIES_CURSOR_TESTS_ABBREV_BUF;
+    let debug_abbrev = DebugAbbrev::<LittleEndian>::new(abbrevs_buf);
+
+    let abbrevs = unit.abbreviations(debug_abbrev)
+        .expect("Should parse abbreviations");
+
+    let mut cursor = unit.entries(&abbrevs);
+
+    assert_next_entry(&mut cursor, "001");
+    assert_next_entry(&mut cursor, "002");
+    assert_next_entry(&mut cursor, "003");
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry(&mut cursor, "004");
+    assert_next_entry(&mut cursor, "005");
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry(&mut cursor, "006");
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry(&mut cursor, "007");
+    assert_next_entry(&mut cursor, "008");
+    assert_next_entry(&mut cursor, "009");
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry(&mut cursor, "010");
+    assert_next_entry_null(&mut cursor);
+    assert_next_entry_null(&mut cursor);
+
+    assert!(cursor.next_entry().expect("Should parse next entry").is_none());
+    assert!(cursor.current().expect("Should parse current entry").is_none());
+}
 
 #[test]
 #[cfg_attr(rustfmt, rustfmt_skip)]

--- a/tests/entries_cursor.rs
+++ b/tests/entries_cursor.rs
@@ -9,9 +9,7 @@ fn assert_current_name<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCurso
                                                        name: &'static str)
     where Endian: Endianity
 {
-    let entry = cursor.current()
-        .expect("Should have an entry result")
-        .expect("and it should be ok");
+    let entry = cursor.current().expect("Should have an entry result");
 
     let value = entry.attr_value(gimli::DW_AT_name)
         .expect("Should have found the name attribute");
@@ -46,7 +44,7 @@ fn assert_next_entry_null<'input, 'abbrev, 'unit, Endian>(cursor: &mut EntriesCu
     cursor.next_entry()
         .expect("Should parse next entry")
         .expect("Should have an entry");
-    // assert!(cursor.current().expect("Should parse current entry").is_none());
+    assert!(cursor.current().is_none());
 }
 
 #[cfg(test)]
@@ -263,7 +261,7 @@ fn test_cursor_next_entry() {
     assert_next_entry_null(&mut cursor);
 
     assert!(cursor.next_entry().expect("Should parse next entry").is_none());
-    assert!(cursor.current().expect("Should parse current entry").is_none());
+    assert!(cursor.current().is_none());
 }
 
 #[test]
@@ -284,7 +282,7 @@ fn test_cursor_next_dfs() {
 
     let mut cursor = unit.entries(&abbrevs);
 
-    assert_current_name(&mut cursor, "001");
+    assert_next_dfs(&mut cursor, "001", 0);
     assert_next_dfs(&mut cursor, "002", 1);
     assert_next_dfs(&mut cursor, "003", 1);
     assert_next_dfs(&mut cursor, "004", -1);
@@ -296,7 +294,7 @@ fn test_cursor_next_dfs() {
     assert_next_dfs(&mut cursor, "010", -2);
 
     assert!(cursor.next_dfs().expect("Should parse next dfs").is_none());
-    assert!(cursor.current().expect("Should parse current entry").is_none());
+    assert!(cursor.current().is_none());
 }
 
 #[test]
@@ -317,7 +315,7 @@ fn test_cursor_next_sibling_no_sibling_ptr() {
 
     let mut cursor = unit.entries(&abbrevs);
 
-    assert_current_name(&mut cursor, "001");
+    assert_next_dfs(&mut cursor, "001", 0);
 
     // Down to the first child of the root entry.
 
@@ -332,7 +330,7 @@ fn test_cursor_next_sibling_no_sibling_ptr() {
     // There should be no more siblings.
 
     assert!(cursor.next_sibling().expect("Should parse next sibling").is_none());
-    assert!(cursor.current().expect("Should parse current entry").is_none());
+    assert!(cursor.current().is_none());
 }
 
 #[test]
@@ -353,7 +351,7 @@ fn test_cursor_next_sibling_continuation() {
 
     let mut cursor = unit.entries(&abbrevs);
 
-    assert_current_name(&mut cursor, "001");
+    assert_next_dfs(&mut cursor, "001", 0);
 
     // Down to the first child of the root entry.
 
@@ -377,7 +375,7 @@ fn test_cursor_next_sibling_continuation() {
     // There should be no more siblings.
 
     assert!(cursor.next_sibling().expect("Should parse next sibling").is_none());
-    assert!(cursor.current().expect("Should parse current entry").is_none());
+    assert!(cursor.current().is_none());
 }
 
 #[test]
@@ -526,7 +524,7 @@ fn test_cursor_next_sibling_with_sibling_ptr() {
 
     let mut cursor = unit.entries(&abbrevs);
 
-    assert_current_name(&mut cursor, "001");
+    assert_next_dfs(&mut cursor, "001", 0);
 
     // Down to the first child of the root.
 
@@ -540,5 +538,5 @@ fn test_cursor_next_sibling_with_sibling_ptr() {
     // There should be no more siblings.
 
     assert!(cursor.next_sibling().expect("Should parse next sibling").is_none());
-    assert!(cursor.current().expect("Should parse current entry").is_none());
+    assert!(cursor.current().is_none());
 }

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -36,9 +36,7 @@ fn test_parse_self_debug_info() {
         let mut cursor = unit.entries(&abbrevs);
 
         while cursor.next_dfs().expect("Should parse next dfs").is_some() {
-            let entry = cursor.current()
-                .expect("Should have a current entry")
-                .expect("And should parse that entry OK");
+            let entry = cursor.current().expect("Should have a current entry");
 
             for attr in entry.attrs() {
                 attr.expect("Should parse entry's attribute");

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -35,17 +35,13 @@ fn test_parse_self_debug_info() {
 
         let mut cursor = unit.entries(&abbrevs);
 
-        loop {
+        while cursor.next_dfs().expect("Should parse next dfs").is_some() {
             let entry = cursor.current()
                 .expect("Should have a current entry")
                 .expect("And should parse that entry OK");
 
             for attr in entry.attrs() {
                 attr.expect("Should parse entry's attribute");
-            }
-
-            if let None = cursor.next_dfs().expect("Should parse next dfs") {
-                break;
             }
         }
     }

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -44,7 +44,7 @@ fn test_parse_self_debug_info() {
                 attr.expect("Should parse entry's attribute");
             }
 
-            if let None = cursor.next_dfs() {
+            if let None = cursor.next_dfs().expect("Should parse next dfs") {
                 break;
             }
         }


### PR DESCRIPTION
The main changes are:

- delete `current_ref`
- `current` now returns a reference to the cached entry, and never parses anything.
- add `next_entry`, which parses a single entry and caches it. The cached entry may be `None` after calling this if the entry was a null.
- `next_dfs` and `next_sibling` now parse the next entry and cache it.
- reaching the last child in `next_sibling` no longer exhausts the cursor. You can call `next_dfs` for example.
- for a new cursor, `current` has no meaning until you to call  `next_dfs` to parse the first entry

I think this is an improvement over the current syntax, but it's subjective, and not as much improvement as I was hoping. For example, you can iterate with:

    while let Some(depth) = try!(cursor.next_dfs()) {
        let entry = cursor.current().unwrap();
        ...
    }

This also gives a small performance improvement for `bench_parsing_debug_info` (order of 5%).

The main thing lacking is that I wanted this syntax instead:
`while let Some((entry, depth)) = try!(cursor.next_dfs()) { ... }`
but I had borrow checker problems trying to implement this... maybe need non-lexical borrows, not sure. I'll try another day. I'm not actually convinced this will help performance though.