### PR TITLE
AttrsIter::next() now returns ParseResult<Option<Attribute>>

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -57,10 +57,10 @@ fn bench_parsing_debug_info(b: &mut test::Bencher) {
                 .expect("Should parse abbreviations");
 
             let mut cursor = unit.entries(&abbrevs);
-
             while let Some((_, entry)) = cursor.next_dfs().expect("Should parse next dfs") {
-                for attr in entry.attrs() {
-                    test::black_box(attr.expect("Should parse entry's attribute"));
+                let mut attrs = entry.attrs();
+                while let Some(attr) = attrs.next().expect("Should parse entry's attribute") {
+                    test::black_box(&attr);
                 }
             }
         }

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -83,9 +83,8 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>)
         indent();
         println!("<{}> <{}>", entry.code(), entry.tag());
 
-        for attr in entry.attrs() {
-            let attr = attr.expect("Should parse attribute OK");
-
+        let mut attrs = entry.attrs();
+        while let Some(attr) = attrs.next().expect("Should parse attribute OK") {
             indent();
             println!("    {} = {:?}", attr.name(), attr.value());
         }

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -38,8 +38,8 @@ fn test_parse_self_debug_info() {
         while cursor.next_dfs().expect("Should parse next dfs").is_some() {
             let entry = cursor.current().expect("Should have a current entry");
 
-            for attr in entry.attrs() {
-                attr.expect("Should parse entry's attribute");
+            let mut attrs = entry.attrs();
+            while let Some(_) = attrs.next().expect("Should parse entry's attribute") {
             }
         }
     }


### PR DESCRIPTION
This makes error handling more reliable.

Fixes #21 