### PR TITLE
Implement support for .debug_str

### DIFF
--- a/src/endianity.rs
+++ b/src/endianity.rs
@@ -160,6 +160,15 @@ impl<'input, Endian> Index<usize> for EndianBuf<'input, Endian>
     }
 }
 
+impl<'input, Endian> Index<RangeFrom<usize>> for EndianBuf<'input, Endian>
+    where Endian: Endianity
+{
+    type Output = [u8];
+    fn index(&self, idx: RangeFrom<usize>) -> &Self::Output {
+        &self.0[idx]
+    }
+}
+
 impl<'input, Endian> Deref for EndianBuf<'input, Endian>
     where Endian: Endianity
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,10 +68,11 @@ pub use endianity::{Endianity, EndianBuf, LittleEndian, BigEndian};
 
 mod parser;
 pub use parser::{Error, ParseResult, Format};
-pub use parser::{DebugStrOffset, DebugLocOffset, DebugMacinfoOffset, UnitOffset};
+pub use parser::{DebugLocOffset, DebugMacinfoOffset, UnitOffset};
 pub use parser::{DebugInfo, DebugInfoOffset, UnitHeadersIter, UnitHeader};
 pub use parser::{DebugTypes, DebugTypesOffset, TypeUnitHeadersIter, TypeUnitHeader};
 pub use parser::{EntriesCursor, DebuggingInformationEntry, AttrsIter, Attribute, AttributeValue};
+pub use parser::{DebugStr, DebugStrOffset};
 
 mod abbrev;
 pub use abbrev::{DebugAbbrev, DebugAbbrevOffset, Abbreviations, Abbreviation,

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2859,3 +2859,51 @@ fn test_parse_type_unit_header_64_ok() {
         otherwise => panic!("Unexpected result: {:?}", otherwise),
     }
 }
+
+/// The `DebugStr` struct represents the DWARF strings
+/// found in the `.debug_str` section.
+#[derive(Debug, Clone, Copy)]
+pub struct DebugStr<'input, Endian>
+    where Endian: Endianity
+{
+    debug_str_section: EndianBuf<'input, Endian>,
+}
+
+impl<'input, Endian> DebugStr<'input, Endian>
+    where Endian: Endianity
+{
+    /// Construct a new `DebugStr` instance from the data in the `.debug_str`
+    /// section.
+    ///
+    /// It is the caller's responsibility to read the `.debug_str` section and
+    /// present it as a `&[u8]` slice. That means using some ELF loader on
+    /// Linux, a Mach-O loader on OSX, etc.
+    ///
+    /// ```
+    /// use gimli::{DebugStr, LittleEndian};
+    ///
+    /// # let buf = [0x00, 0x01, 0x02, 0x03];
+    /// # let read_debug_str_section_somehow = || &buf;
+    /// let debug_str = DebugStr::<LittleEndian>::new(read_debug_str_section_somehow());
+    /// ```
+    pub fn new(debug_str_section: &'input [u8]) -> DebugStr<'input, Endian> {
+        DebugStr { debug_str_section: EndianBuf(debug_str_section, PhantomData) }
+    }
+
+    /// Lookup a string from the `.debug_str` section by DebugStrOffset.
+    ///
+    /// ```
+    /// use gimli::{DebugStr, DebugStrOffset, LittleEndian};
+    ///
+    /// # let buf = [0x01, 0x02, 0x00];
+    /// # let offset = DebugStrOffset(0);
+    /// # let read_debug_str_section_somehow = || &buf;
+    /// # let debug_str_offset_somehow = || offset;
+    /// let debug_str = DebugStr::<LittleEndian>::new(read_debug_str_section_somehow());
+    /// println!("Found string {:?}", debug_str.get_str(debug_str_offset_somehow()));
+    /// ```
+    pub fn get_str(&self, offset: DebugStrOffset) -> ParseResult<&ffi::CStr> {
+        let result = parse_null_terminated_string(&self.debug_str_section[offset.0 as usize ..]);
+        result.map(|(_, cstr)| cstr)
+    }
+}


### PR DESCRIPTION
This implements basic support for .debug_str, with a lookup method to give you an ffi::CStr in exchange for a DebugStrOffset.