### PR TITLE
Print DIE offset in dwarfdump instead of abbreviation code

### DIFF
--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -87,7 +87,7 @@ fn dump_entries<Endian>(mut entries: gimli::EntriesCursor<Endian>, debug_str: gi
         };
 
         indent();
-        println!("<{}> <{}>", entry.code(), entry.tag());
+        println!("<{}> <{}>", entry.offset(), entry.tag());
 
         let mut attrs = entry.attrs();
         while let Some(attr) = attrs.next().expect("Should parse attribute OK") {


### PR DESCRIPTION
here's an attempt at resolving https://github.com/fitzgen/gimli/issues/35! This would make the dwarfdump example match better.

I compared the output to what dwarfdump prints and the offsets look right to me. there is probably some terrible Rust in here because my Rust is actually awful :)