### PR TITLE
Make StateMachine::new consume its LineNumberProgramHeader

### DIFF
--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -97,7 +97,7 @@ fn bench_parsing_line_number_program_opcodes(b: &mut test::Bencher) {
             .expect("Should parse line number program header");
 
         let mut opcodes = header.opcodes();
-        while let Some(opcode) = opcodes.next_opcode().expect("Should parse opcode") {
+        while let Some(opcode) = opcodes.next_opcode(&header).expect("Should parse opcode") {
             test::black_box(opcode);
         }
     });
@@ -112,7 +112,7 @@ fn bench_executing_line_number_programs(b: &mut test::Bencher) {
         let header = LineNumberProgramHeader::new(debug_line, OFFSET, ADDRESS_SIZE)
             .expect("Should parse line number program header");
 
-        let mut state_machine = StateMachine::new(&header);
+        let mut state_machine = StateMachine::new(header);
         while let Some(row) = state_machine.next_row()
             .expect("Should parse and execute all rows in the line number program") {
             test::black_box(row);

--- a/examples/dwarfdump.rs
+++ b/examples/dwarfdump.rs
@@ -190,7 +190,8 @@ fn dump_line<Endian>(file: &obj::File, debug_abbrev: gimli::DebugAbbrev<Endian>)
                 println!("");
                 println!("Line Number Statements:");
                 let mut opcodes = header.opcodes();
-                while let Some(opcode) = opcodes.next_opcode().expect("Should parse opcode OK") {
+                while let Some(opcode) = opcodes.next_opcode(&header)
+                    .expect("Should parse opcode OK") {
                     println!("  {}", opcode);
                 }
             }

--- a/tests/parse_self.rs
+++ b/tests/parse_self.rs
@@ -74,7 +74,7 @@ fn test_parse_self_debug_line() {
             let header = LineNumberProgramHeader::new(debug_line, offset, unit.address_size())
                 .expect("should parse line number program header");
 
-            let mut state_machine = StateMachine::new(&header);
+            let mut state_machine = StateMachine::new(header);
             while let Some(_) = state_machine.next_row()
                 .expect("Should parse and execute all rows in the line number program") {
             }


### PR DESCRIPTION
Because executing a line number program can define new file entries, it is
incorrect to pass the same header to multiple `StateMachine`s, which is possible
when the `StateMachine` doesn't consume the header.

Fixes #40

@philipc, mind taking a look?

Unfortunately, this ended up making `OpcodesIter::next_opcode` take a `&header` param instead of storing the reference in the `OpcodesIter` struct itself, but I'm not sure how we could work around that.

This doesn't have any effect on the benches.